### PR TITLE
Prevent commands from executing during tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,3 +16,11 @@ module.exports = {
   },
   verbose: true,
 };
+
+const processStdoutWrite = process.stdout.write.bind(process.stdout);
+
+process.stdout.write = (str, encoding, cb) => {
+  if (!str.match(/^::/)) {
+    return processStdoutWrite(str, encoding, cb);
+  }
+};


### PR DESCRIPTION
This stops the `::commands` from being written out during testing which pollutes the run log.