### PR TITLE
Add new has-command output parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Name | Allowed values | Description
 `allow-edits` | `true`, `false` (default) | Indicates if the action should run on comment edits, or the initial comment only.
 `permission-level` | `admin`, `write` (default), `read`, `none` | The user's [permission level](https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level) needed to act on the command.
 
+## Outputs
+
+Name | Description
+-- | --
+`has-command` | If a command was found in the comment. Will be a string value of `true` or `false`.
+
 ## License
 
 The scripts and documentation in this project are released under the [MIT License](LICENSE)

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,9 @@ outputs:
   command-arguments:
     description: The arguments of the command
 
+  has-command:
+    description: If a command was found in the comment
+
 runs:
   using: "node12"
   main: "dist/index.js"

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,20 +1,26 @@
-import * as core from "@actions/core";
+import {
+  getInput,
+  setFailed,
+  setOutput,
+} from "@actions/core";
 
 import { CommandHandler } from "./commandHandler";
 import { PermissionLevel } from "./interfaces";
 
 export async function run(): Promise<void> {
   try {
-    await new CommandHandler(
-      core.getInput("repo-token", { required: true }),
-      core.getInput("command", { required: true }),
-      core.getInput("reaction") === "true",
-      core.getInput("reaction-type"),
-      core.getInput("allow-edits") === "true",
-      core.getInput("permission-level") as PermissionLevel,
+    const hasCommand = await new CommandHandler(
+      getInput("repo-token", { required: true }),
+      getInput("command", { required: true }),
+      getInput("reaction") === "true",
+      getInput("reaction-type"),
+      getInput("allow-edits") === "true",
+      getInput("permission-level") as PermissionLevel,
     ).process();
+
+    setOutput("has-command", hasCommand.toString());
   } catch (error) {
-    core.setFailed(error.message);
+    setFailed(error.message);
     throw error;
   }
 }


### PR DESCRIPTION
This builds on #136 and adds a new `has-command` out parameter that can be used to check if the job should continue or not.