### PR TITLE
Default `repo-token` input to `GITHUB_TOKEN`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Updated node runtime from 12 to 16
+- Updated the `repo-token` input so it defaults to `GITHUB_TOKEN`. If you're already using this value you can remove this setting from your workflow.
 
 ## [1.2.0](https://github.com/xt0rted/slash-command-action/compare/v1.1.0...v1.2.0) - 2022-10-23
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ It will only run on the initial comment, not on edits, and when the action runs 
 ```yaml
 on: issue_comment
 name: Issue Comments
+permissions:
+  issues: write
 jobs:
   check_comments:
     name: Check comments for /test
@@ -23,7 +25,6 @@ jobs:
         id: command
         uses: xt0rted/slash-command-action@v1
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           command: test
           reaction: "true"
           reaction-type: "eyes"
@@ -39,7 +40,7 @@ jobs:
 
 Name | Allowed values | Description
 -- | -- | --
-`repo-token` | `GITHUB_TOKEN` or a custom value | The token used to call the GitHub api.
+`repo-token` | `GITHUB_TOKEN` (default) or PAT | `GITHUB_TOKEN` token or a PAT.
 `command` | `[a-zA-Z0-9_]` | The command to act on. You can test how your command will be parsed [here](https://regex101.com/r/7XptVD).
 
 ### Optional

--- a/action.yml
+++ b/action.yml
@@ -10,8 +10,9 @@ branding:
 
 inputs:
   repo-token:
-    description: The GITHUB_TOKEN secret
+    description: GITHUB_TOKEN token or a PAT
     required: true
+    default: ${{ github.token }}
 
   command:
     description: The command to act on


### PR DESCRIPTION
This update makes it so the `repo-token` input value defaults to `GITHUB_TOKEN` which is the most common value to be used as it provides the necessary permissions. This is a backwards compatible change.