### PR TITLE
Add support for collaborator roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Name | Allowed values | Description
 `reaction` | `true` (default), `false` | Indicates if a reaction is left on the comment indicating it was seen.
 `reaction-type` | `+1` (default), `-1`, `laugh`, `confused`, `heart`, `hooray`, `rocket`, `eyes` | The [reaction type](https://developer.github.com/v3/reactions/#reaction-types) to leave on the comment.
 `allow-edits` | `true`, `false` (default) | Indicates if the action should run on comment edits, or the initial comment only.
-`permission-level` | `admin`, `write` (default), `read`, `none` | The user's [permission level](https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level) needed to act on the command.
+`permission-level` | `admin`, `maintain`, `write` (default), `triage`, `read`, `none` | The user's [permission level](https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level) needed to act on the command.
 
 ## License
 

--- a/__tests__/commandHandler.test.ts
+++ b/__tests__/commandHandler.test.ts
@@ -72,8 +72,6 @@ describe("commandHandler", () => {
     });
 
     it("should return false when correct slash command but incorrect repo access", async () => {
-      const mockedSetOutput = core.setOutput as jest.Mock<typeof core.setOutput>;
-
       context.payload = require(join(__dirname, "payloads", "created.json"));
 
       const commandHandler = new CommandHandler(
@@ -90,6 +88,27 @@ describe("commandHandler", () => {
         .reply(200, { permission: "read" });
 
       await expect(commandHandler.process()).resolves.toBe(false);
+
+      expect(scoped.isDone()).toBe(true);
+    });
+
+    it("should return true when repo access being used is greather than the required one", async () => {
+      context.payload = require(join(__dirname, "payloads", "created.json"));
+
+      const commandHandler = new CommandHandler(
+        /* repoToken */ "-token-",
+        /* commandName */ "test",
+        /* addReaction */ false,
+        /* reactionType */ "+1",
+        /* allowEdits */ false,
+        /* requiredPermissionLevel */ "write",
+      );
+
+      const scoped = nock("https://api.github.com")
+        .get("/repos/xt0rted/slash-command-action/collaborators/test-user/permission")
+        .reply(200, { permission: "maintain" });
+
+      await expect(commandHandler.process()).resolves.toBe(true);
 
       expect(scoped.isDone()).toBe(true);
     });

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -1,6 +1,8 @@
 export type PermissionLevel =
   | "admin"
+  | "maintain"
   | "write"
+  | "triage"
   | "read"
   | "none"
   ;

--- a/src/permission.ts
+++ b/src/permission.ts
@@ -3,8 +3,10 @@ import type { PermissionLevel } from "./interfaces";
 export enum PermissionLevels {
   none = 0,
   read = 1,
-  write = 2,
-  admin = 3,
+  triage = 2,
+  write = 3,
+  maintain = 4,
+  admin = 5,
 }
 
 export function checkPermission(required: PermissionLevel, actual: PermissionLevel): boolean {


### PR DESCRIPTION
Closes #563 

This patch adds support for the 2 collaborator roles: `triage` and `maintain`.
